### PR TITLE
 Documentation for upload resources without the Arduino IDE 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -105,8 +105,12 @@ TTGO Badge & TTGO EPaper Series
 ## Upload webserver resource
 - Use Arduino ESP32 Sketch data Upload files,if you not install,[download ESP32FS-vX.zip](https://github.com/me-no-dev/arduino-esp32fs-plugin/releases),Extract to <C:\Users\Your User Name\Documents\Arduino\tools>,Open Ardunio IDE,  Tools -> ESP32 Sketch data Upload -> Upload
 
-## Configure Badge Website
+- With PlatformIO also you can upload files, with the next command:
+```bash
+pio run --target uploadfs
+```
 
+## Configure Badge Website
 - **Configure the badge by entering http://ttgo.local or ip address in your browser.**
 ![](images/3.png)
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,8 +16,8 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 2000000
 
-monitor_port = COM31
-upload_port= COM31
+;monitor_port = COM31
+;upload_port= COM31
 
 lib_deps =
     ; ArduinoJson@6.14.1


### PR DESCRIPTION
- added documentation for `pio` alternative for upload resources without  `ESP32FS-vX` plugin
- commented some lines in `platformio.ini` that was only for windows, in order of improve upload-port auto detection in other OS