### PR TITLE
Fixed Included files extensions

### DIFF
--- a/TTGO-Badge.ino
+++ b/TTGO-Badge.ino
@@ -1,22 +1,22 @@
 // include library, include base class, make path known
 #include <GxEPD.h>
-#include <GxIO/GxIO_SPI/GxIO_SPI.cpp>
-#include <GxIO/GxIO.cpp>
+#include <GxIO/GxIO_SPI/GxIO_SPI.h>
+#include <GxIO/GxIO.h>
 // select the display class to use, only one
-//#include <GxGDEP015OC1/GxGDEP015OC1.cpp>    // 1.54" b/w
-//#include <GxGDEW0154Z04/GxGDEW0154Z04.cpp>  // 1.54" b/w/r 200x200
-//#include <GxGDEW0154Z17/GxGDEW0154Z17.cpp>  // 1.54" b/w/r 152x152
-//#include <GxGDE0213B1/GxGDE0213B1.cpp>      // 2.13" b/w
-//#include <GxGDEW0213Z16/GxGDEW0213Z16.cpp>  // 2.13" b/w/r
-#include <GxGDEH029A1/GxGDEH029A1.cpp> // 2.9" b/w
-//#include <GxGDEW029Z10/GxGDEW029Z10.cpp>    // 2.9" b/w/r
-//#include <GxGDEW027C44/GxGDEW027C44.cpp>    // 2.7" b/w/r
-// #include <GxGDEW027W3/GxGDEW027W3.cpp> // 2.7" b/w
-//#include <GxGDEW042T2/GxGDEW042T2.cpp>      // 4.2" b/w
-//#include <GxGDEW042Z15/GxGDEW042Z15.cpp>    // 4.2" b/w/r
-//#include <GxGDEW0583T7/GxGDEW0583T7.cpp>    // 5.83" b/w
-//#include <GxGDEW075T8/GxGDEW075T8.cpp>      // 7.5" b/w
-//#include <GxGDEW075Z09/GxGDEW075Z09.cpp>    // 7.5" b/w/r
+//#include <GxGDEP015OC1/GxGDEP015OC1.h>    // 1.54" b/w
+//#include <GxGDEW0154Z04/GxGDEW0154Z04.h>  // 1.54" b/w/r 200x200
+//#include <GxGDEW0154Z17/GxGDEW0154Z17.h>  // 1.54" b/w/r 152x152
+//#include <GxGDE0213B1/GxGDE0213B1.h>      // 2.13" b/w
+//#include <GxGDEW0213Z16/GxGDEW0213Z16.h>  // 2.13" b/w/r
+#include <GxGDEH029A1/GxGDEH029A1.h> // 2.9" b/w
+//#include <GxGDEW029Z10/GxGDEW029Z10.h>    // 2.9" b/w/r
+//#include <GxGDEW027C44/GxGDEW027C44.h>    // 2.7" b/w/r
+// #include <GxGDEW027W3/GxGDEW027W3.h> // 2.7" b/w
+//#include <GxGDEW042T2/GxGDEW042T2.h>      // 4.2" b/w
+//#include <GxGDEW042Z15/GxGDEW042Z15.h>    // 4.2" b/w/r
+//#include <GxGDEW0583T7/GxGDEW0583T7.h>    // 5.83" b/w
+//#include <GxGDEW075T8/GxGDEW075T8.h>      // 7.5" b/w
+//#include <GxGDEW075Z09/GxGDEW075Z09.h>    // 7.5" b/w/r
 
 #include <Fonts/FreeMono9pt7b.h>
 #include <Fonts/FreeMonoBoldOblique9pt7b.h>


### PR DESCRIPTION
There was many errors because of wrong file extensions. Can't include .cpp files. Now included files have .h extension.